### PR TITLE
Added Python 3 support

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -8,6 +8,10 @@ if [ `uname` != "Darwin" ]; then
     export DYLIB="so"
 fi
 
+PY_VER=$(python -c "import sys; print('{}.{}'.format(*sys.version_info[:2]))")
+PY_ABIFLAGS=$(python -c "import sys; print('' if sys.version_info.major == 2 else sys.abiflags)")
+PY_ABI=${PY_VER}${PY_ABIFLAGS}
+
 cmake .. \
     -DCMAKE_C_COMPILER=${PREFIX}/bin/gcc \
     -DCMAKE_CXX_COMPILER=${PREFIX}/bin/g++ \
@@ -15,9 +19,9 @@ cmake .. \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
     -DPYTHON_EXECUTABLE=${PYTHON} \
-    -DPYTHON_LIBRARY=${PREFIX}/lib/libpython2.7.${DYLIB} \
-    -DPYTHON_INCLUDE_DIR=${PREFIX}/include/python2.7 \
-    -DPYTHON_INCLUDE_DIR2=${PREFIX}/include/python2.7 \
+    -DPYTHON_LIBRARY=${PREFIX}/lib/libpython${PY_ABI}.${DYLIB} \
+    -DPYTHON_INCLUDE_DIR=${PREFIX}/include/python${PY_ABI} \
+    -DPYTHON_INCLUDE_DIR2=${PREFIX}/include/python${PY_ABI} \
     -DWITH_LOG=OFF
 
 make -j${CPU_COUNT}

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,17 +1,26 @@
 mkdir build
 cd build
 
-LINKER_FLAGS="-L${PREFIX}/lib"
-export DYLIB="dylib"
-if [ `uname` != "Darwin" ]; then
-    LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib ${LINKER_FLAGS}"
+if [ $(uname) == "Darwin" ]; then
+    CC=clang
+    CXX=clang++
+    CXXFLAGS="-std=c++11 -stdlib=libc++"
+    
+    export DYLIB="dylib"
+    LINKER_FLAGS="-L${PREFIX}/lib"
+else
+    CC=${PREFIX}/bin/gcc
+    CXX=${PREFIX}/bin/g++
     export DYLIB="so"
+    LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
 fi
 
+
 cmake .. \
-    -DCMAKE_C_COMPILER=${PREFIX}/bin/gcc \
-    -DCMAKE_CXX_COMPILER=${PREFIX}/bin/g++ \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 \
+    -DCMAKE_C_COMPILER=${CC} \
+    -DCMAKE_CXX_COMPILER=${CXX} \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
     -DPYTHON_EXECUTABLE=${PYTHON} \

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,6 +37,9 @@ requirements:
     - python {{PY_VER}}*
 
 test:
+  source_files:
+    - test
+
   imports:
     - dpct
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,14 +22,17 @@ requirements:
     - gcc 4.8.5 # [linux]
     - gcc 4.8.5 # [osx]
     - patchelf # [linux]
-    - boost 1.55.0
+    - boost 1.55.0 # [py2k]
+    - boost 1.60.0 # [py3k]
     - lemon
+    - python 2.7*|3.5*
     - python {{PY_VER}}*
 
   run:
     - libgcc 4.8.5
     - patchelf # [linux]
-    - boost 1.55.0
+    - boost 1.55.0 # [py2k]
+    - boost 1.60.0 # [py3k]
     - lemon
     - python {{PY_VER}}*
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - boost 1.55.0 # [py2k]
     - boost 1.63.0 # [py3k]
     - lemon
-    - python 2.7*|3.5*
     - python {{PY_VER}}*
 
   run:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,16 +20,15 @@ build:
 requirements:
   build:
     - gcc 4.8.5 # [linux]
-    - gcc 4.8.5 # [osx]
     - patchelf # [linux]
-    - boost 1.55.0
+    - boost 1.63.0
     - lemon
     - python {{PY_VER}}*
 
   run:
-    - libgcc 4.8.5
+    - libgcc 4.8.5 # [linux]
     - patchelf # [linux]
-    - boost 1.55.0
+    - boost 1.63.0
     - lemon
     - python {{PY_VER}}*
 

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -1,0 +1,1 @@
+python test/test.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 
 # include external headers as system includes so we do not have to cope with their warnings
-include_directories( SYSTEM ${Boost_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS}/python2.7 )
+include_directories( SYSTEM ${Boost_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS} )
 
 # pydpct
 set(PYDPCT_SRCS pydpct.cpp pythongraphreader.cpp)
@@ -43,7 +43,7 @@ endif()
 # make use of ${PYTHON_EXECUTABLE} instead of /usr/bin/python
 if(NOT DEFINED PYDPCT_INSTALL_DIR OR PYDPCT_INSTALL_DIR MATCHES "^$")
     execute_process(COMMAND ${PYTHON_EXECUTABLE} -c 
-                    "from distutils.sysconfig import *; print get_python_lib(1)"
+                    "from distutils.sysconfig import *; print(get_python_lib(1))"
                     OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
     file(TO_CMAKE_PATH ${PYTHON_SITE_PACKAGES} PYDPCT_INSTALL_DIR)
 endif()

--- a/scripts/plotNodesPerIterSurface.py
+++ b/scripts/plotNodesPerIterSurface.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
     print(surf.shape)
 
     from mpl_toolkits.mplot3d import Axes3D # for 3D surface plot
-    x, y = np.meshgrid(range(surf.shape[1]), range(surf.shape[0]))
+    x, y = np.meshgrid(list(range(surf.shape[1]), range(surf.shape[0])))
     print(x.shape)
     print(y.shape)
 

--- a/src/magnusson.cpp
+++ b/src/magnusson.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <sstream>
+#include <random>
 
 #include "magnusson.h"
 #include "trackingalgorithm.h"


### PR DESCRIPTION
This PR adds Python 3 support (without removing Python 2 compatibility).

One small note: In the conda recipe, I use a different version of boost depending on whether or not you're using Python 2 or Python 3.  There's no fundamental reason for that.  Here's why I did it that way:

- For now, the rest of the ilastik stack still uses as special Python-2-only build of boost 1.55, and I want to keep compatibility with other ilastik packages.
- For the Python 3 case, I chose 1.60.0 somewhat arbitrarily (I happened to know it worked on my machine and I didn't feel like experimenting).  I might upgrade to boost-1.63 before "releasing" ilastik's py3 packages, but for now I'm sticking with 1.60.0.

